### PR TITLE
Update group.md

### DIFF
--- a/routing/group.md
+++ b/routing/group.md
@@ -25,7 +25,9 @@ drop.group("v1") { v1 in
 Grouped returns a `GroupBuilder` that you can pass around.
 
 ```swift
-let v1 = drop.grouped("v1")
+import Routing
+
+let v1: RouteGroup = drop.grouped("v1")
 v1.get("users") { request in
     // get the users
 }


### PR DESCRIPTION
Added implicitly declaring grouped properties as a RouteGroup type, which also requires importing the Routing module. See https://github.com/vapor/vapor/issues/662